### PR TITLE
Automatic PDF generation

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -13,8 +13,7 @@ jobs:
         uses: docker://pandoc/core:2.9
         with:
           args: |
-            --output=recommendations.pdf
-            recommendations.md
+            --output=recommendations.pdf recommendations.md
       - uses: actions/setup-node@v1
         with:
           node-version: '12'

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Combine recommendations into single file
         run: ./convert.sh  # create an example file
       - name: Convert to PDF
-        uses: docker://pandoc/core:2.9
+        uses: docker://pandoc/latex:2.9
         with:
           args: |
             --output=recommendations.pdf recommendations.md

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -1,0 +1,24 @@
+name: Generate PDF
+
+on: push
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Combine recommendations into single file
+        run: ./convert.sh  # create an example file
+      - name: Convert to PDF
+        uses: docker://pandoc/core:2.9
+        with:
+          args: |
+            --output=recommendations.pdf
+            recommendations.md
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - name: Upload PDF to Zenodo
+        run: npx --package @iomeg/zenodo-upload zenodo_upload --sandbox 711602 recommendations.pdf "version_test01" ${{ secrets.ZENODO_TOKEN }}
+        env:
+          github_ref: ${{ github.ref }}

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -1,7 +1,8 @@
 name: Generate PDF
 
-on: push
-
+on:
+  release:
+    types: [published]
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -18,6 +19,6 @@ jobs:
         with:
           node-version: '12'
       - name: Upload PDF to Zenodo
-        run: npx --package @iomeg/zenodo-upload zenodo_upload --sandbox 711602 recommendations.pdf "version_test01" ${{ secrets.ZENODO_TOKEN }}
+        run: npx --package @iomeg/zenodo-upload zenodo_upload --sandbox 711602 recommendations.pdf "${github_ref:10}" ${{ secrets.ZENODO_TOKEN }}
         env:
           github_ref: ${{ github.ref }}

--- a/convert.sh
+++ b/convert.sh
@@ -1,0 +1,26 @@
+# Merge into a single file
+cat README.md > recommendations.md
+echo " " >> recommendations.md
+cat repository.md >> recommendations.md
+echo " " >> recommendations.md
+cat license.md >> recommendations.md
+echo " " >> recommendations.md
+cat registry.md >> recommendations.md
+echo " " >> recommendations.md
+cat citation.md >> recommendations.md
+echo " " >> recommendations.md
+cat checklist.md >> recommendations.md
+echo " " >> recommendations.md
+cat fair.md >> recommendations.md
+
+# Replace links to section headers
+sed -i 's/checklist.md/#use-a-software-quality-checklist/' recommendations.md
+sed -i 's/citation.md/#enable-citation-of-the-software/' recommendations.md
+sed -i 's/license.md/#add-a-license/' recommendations.md
+sed -i 's/registry.md/#register-your-code-in-a-community-registry/' recommendations.md
+sed -i 's/repository.md/#use-a-publicly-accessible-repository-with-version-control/' recommendations.md
+sed -i 's/fair.md/#what-is-fair/' recommendations.md
+sed -i 's,LICENSE,https://github.com/fair-software/fair-software-recommendations/blob/master/LICENSE,' recommendations.md
+
+# Convert to PDF
+# pandoc recommendations.md -o recommendations.pdf  


### PR DESCRIPTION
This PR adds a github action to automatically generate a PDF from the recommendations.

If this is to be merged, we need:
 - Create a zenodo depositon where new versions will be posted
 - Change deposition_id number on pdf.yml 
 - Add secrets.ZENODO_TOKEN
 - Add a link to zenodo on readme.md
